### PR TITLE
Fix to exclude not GWT compat classses

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai.gwt.xml
+++ b/gdx-ai/src/com/badlogic/gdx/ai.gwt.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
 <module>
-	<source path="ai"/>
+    <source path="ai">
+        <exclude name="**/btree/**"/>
+        <exclude name="**/steer/**"/>
+    </source>
 </module>


### PR DESCRIPTION
https://github.com/libgdx/gdx-ai/issues/10

Temporary work around, excluding the code that isn't compatible
