### PR TITLE
Add "shortCircuit" task attribute to Parallel task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 
 ext {
 	projectGroup = "gdx-ai"
-	gdxVersion = '1.6.5-SNAPSHOT'
+	gdxVersion = '1.6.5'
 }
 
 /** needed to disable Java 8 doclint which throws errors **/

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/BranchTask.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/BranchTask.java
@@ -74,6 +74,15 @@ public abstract class BranchTask<E> extends Task<E> {
 		runningTask = null;
 	}
 
+    @Override
+    public void end(){
+        // end all running children
+        for (int i = 0; i < children.size; i++) {
+            Task<E> child = children.get(i);
+            child.end();
+        }
+    }
+
 	@Override
 	public void reset () {
 		super.reset();

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -91,6 +91,18 @@ public class Parallel<E> extends BranchTask<E> {
 		}
 	}
 
+    @Override
+    public void end() {
+        // end all running children
+        for (int i = 0; i < children.size; i++) {
+            Task<E> child = children.get(i);
+            if (runningTasks[i]) {
+                child.end();
+                runningTasks[i] = false;
+            }
+        }
+    }
+
 	@Override
 	public void childRunning (Task<E> task, Task<E> reporter) {
 		runningTasks[currentChildIndex] = true;
@@ -118,16 +130,7 @@ public class Parallel<E> extends BranchTask<E> {
 		if (noRunningTasks && currentChildIndex == children.size - 1) {
 			fail();
 		} else if(shortCircuit) {
-
-            // end all running children
-            for (int i = 0; i < children.size; i++) {
-                Task<E> child = children.get(i);
-                if (runningTasks[i]) {
-                    child.end();
-                    runningTasks[i] = false;
-                }
-            }
-
+            end();
             fail();
         }
 	}

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.ai.btree.branch;
 
 import com.badlogic.gdx.ai.btree.BranchTask;
 import com.badlogic.gdx.ai.btree.Task;
+import com.badlogic.gdx.ai.btree.annotation.TaskAttribute;
 import com.badlogic.gdx.utils.Array;
 
 /** A {@code Parallel} is a special branch task that starts or resumes all children every single time, parallel task will succeed
@@ -34,6 +35,11 @@ public class Parallel<E> extends BranchTask<E> {
 	private boolean success;
 	private boolean noRunningTasks;
 	private int currentChildIndex;
+
+    /** Determines whether the parallel task will fail
+     *  immediately upon failure of a child */
+    @TaskAttribute
+    public boolean shortCircuit = false;
 
 	/** Creates a parallel task with no children */
 	public Parallel () {
@@ -69,7 +75,12 @@ public class Parallel<E> extends BranchTask<E> {
 	public void run () {
 		noRunningTasks = true;
 		for (currentChildIndex = 0; currentChildIndex < children.size; currentChildIndex++) {
-			Task<E> child = children.get(currentChildIndex);
+
+            // If using 'shortCircuit' and a child fails, need to break
+            // the for loop to prevent running the rest of the children
+            if(shortCircuit && !success) break;
+
+            Task<E> child = children.get(currentChildIndex);
 			if (runningTasks[currentChildIndex]) {
 				child.run();
 			} else {
@@ -106,7 +117,19 @@ public class Parallel<E> extends BranchTask<E> {
 		success = false;
 		if (noRunningTasks && currentChildIndex == children.size - 1) {
 			fail();
-		}
+		} else if(shortCircuit) {
+
+            // end all running children
+            for (int i = 0; i < children.size; i++) {
+                Task<E> child = children.get(i);
+                if (runningTasks[i]) {
+                    child.end();
+                    runningTasks[i] = false;
+                }
+            }
+
+            fail();
+        }
 	}
 
 	@Override

--- a/tests/data/dogParallel.tree
+++ b/tests/data/dogParallel.tree
@@ -1,0 +1,22 @@
+#
+# Dog2 tree - uses short circuit parallel task
+#
+
+# Alias definitions
+import bark:"com.badlogic.gdx.ai.tests.btree.dog.BarkTask"
+import care:"com.badlogic.gdx.ai.tests.btree.dog.CareTask"
+import mark:"com.badlogic.gdx.ai.tests.btree.dog.MarkTask"
+import walk:"com.badlogic.gdx.ai.tests.btree.dog.WalkTask"
+import play:"com.badlogic.gdx.ai.tests.btree.dog.PlayTask"
+
+# Tree definition (note that root is optional)
+root
+  selector
+    parallel shortCircuit:true
+      care urgentProb:0.8
+      play
+    sequence
+      bark times:"uniform,1,5"
+      walk
+      com.badlogic.gdx.ai.tests.btree.dog.BarkTask # fully qualified task
+      mark

--- a/tests/src/com/badlogic/gdx/ai/tests/BehaviorTreeTests.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/BehaviorTreeTests.java
@@ -19,11 +19,7 @@ package com.badlogic.gdx.ai.tests;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.ai.tests.btree.BehaviorTreeTestBase;
-import com.badlogic.gdx.ai.tests.btree.tests.IncludeSubtreeTest;
-import com.badlogic.gdx.ai.tests.btree.tests.ParseAndRunTest;
-import com.badlogic.gdx.ai.tests.btree.tests.ParseCloneAndRunTest;
-import com.badlogic.gdx.ai.tests.btree.tests.ProgrammaticallyCreatedTest;
-import com.badlogic.gdx.ai.tests.btree.tests.SemaphoreGuardTest;
+import com.badlogic.gdx.ai.tests.btree.tests.*;
 import com.badlogic.gdx.ai.tests.utils.GdxAiTest;
 import com.badlogic.gdx.ai.tests.utils.scene2d.CollapsableWindow;
 import com.badlogic.gdx.graphics.GL20;
@@ -62,7 +58,8 @@ public class BehaviorTreeTests extends GdxAiTest {
 		new IncludeSubtreeTest(this, true),
 		new ProgrammaticallyCreatedTest(this, false),
 		new ProgrammaticallyCreatedTest(this, true),
-		new SemaphoreGuardTest(this)
+		new SemaphoreGuardTest(this),
+        new ParallelShortCircuitTest(this)
 	};
 	// @on - enable libgdx formatter
 

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/dog/CareTask.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/dog/CareTask.java
@@ -35,7 +35,7 @@ public class CareTask extends LeafTask<Dog> {
 			Dog dog = getObject();
 			dog.brainLog("It's leaking out!!!");
 			dog.setUrgent(true);
-			success();
+			fail();
 		}
 	}
 

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/dog/PlayTask.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/dog/PlayTask.java
@@ -1,0 +1,33 @@
+package com.badlogic.gdx.ai.tests.btree.dog;
+
+import com.badlogic.gdx.ai.btree.LeafTask;
+import com.badlogic.gdx.ai.btree.Task;
+
+/**
+ * Created by DESK-W7 on 9/11/2015.
+ */
+public class PlayTask extends LeafTask<Dog> {
+
+    public void start(){
+        Dog dog = getObject();
+        dog.brainLog("Lets play!");
+    }
+
+    @Override
+    public void run () {
+        Dog dog = getObject();
+        dog.brainLog("-pant pant-");
+        running();
+    }
+
+    @Override
+    public void end(){
+        Dog dog = getObject();
+        dog.brainLog("No time to play");
+    }
+
+    @Override
+    protected Task<Dog> copyTo(Task<Dog> task) {
+        return task;
+    }
+}

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/tests/ParallelShortCircuitTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/tests/ParallelShortCircuitTest.java
@@ -1,0 +1,56 @@
+package com.badlogic.gdx.ai.tests.btree.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.ai.btree.BehaviorTree;
+import com.badlogic.gdx.ai.btree.utils.BehaviorTreeParser;
+import com.badlogic.gdx.ai.tests.BehaviorTreeTests;
+import com.badlogic.gdx.ai.tests.btree.BehaviorTreeTestBase;
+import com.badlogic.gdx.ai.tests.btree.dog.Dog;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.utils.StreamUtils;
+
+import java.io.Reader;
+
+/**
+ * Created by DESK-W7 on 9/11/2015.
+ */
+public class ParallelShortCircuitTest extends BehaviorTreeTestBase {
+
+    private BehaviorTree<Dog> dogBehaviorTree;
+    private float elapsedTime;
+    private int step;
+
+    public ParallelShortCircuitTest (BehaviorTreeTests container) {
+        super(container, "Parallel Short Circuit");
+    }
+
+    @Override
+    public void create (Table table) {
+        elapsedTime = 0;
+        step = 0;
+
+        Reader reader = null;
+        try {
+            reader = Gdx.files.internal("data/dogParallel.tree").reader();
+            BehaviorTreeParser<Dog> parser = new BehaviorTreeParser<Dog>(BehaviorTreeParser.DEBUG_NONE);
+            dogBehaviorTree = parser.parse(reader, new Dog("Snowball"));
+        } finally {
+            StreamUtils.closeQuietly(reader);
+        }
+    }
+
+    @Override
+    public void render () {
+        elapsedTime += Gdx.graphics.getRawDeltaTime();
+
+        if (elapsedTime > 0.8f) {
+            System.out.println("Step: " + (++step));
+            dogBehaviorTree.step();
+            elapsedTime = 0;
+        }
+    }
+
+    @Override
+    public void dispose () {
+    }
+}


### PR DESCRIPTION
 This will allow the Parallel task to fail when one child fails. If a child fails, the Parallel task will call `end()` on all running children and prevent starting any remaining children.

I mimicked the original Dog test, but instead of Rest, I created Play. The main difference is that Play is not checking for any conditions itself, this is instead handled by the Parallel task.