### PR TITLE
Behavior tree poolable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
 [1.8.1-SNAPSHOT]
+- API Change and Addition: Allow use of Pool with Behavior Tree
+  * Task reset method renamed resetTask to avoid conflicts with Poolable interface.
+  * Task implements Poolable interface.
+  * Pool based behavior tree library implementation provided.
 - Fix: division by zero in Separation behavior.
 - Fix: in FollowFlowField behavior the predicted position was affecting steering.
 - Fix: stackoverflow in Sequence with guarded Task.

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/BehaviorTree.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/BehaviorTree.java
@@ -169,6 +169,15 @@ public class BehaviorTree<E> extends Task<E> {
 			listener.childAdded(task, index);
 		}
 	}
+	
+	@Override
+	public void reset() {
+		removeListeners();
+		this.rootTask = null;
+		this.object = null;
+		this.listeners = null;
+		super.reset();
+	}
 
 	private static final class GuardEvaluator<E> extends Task<E> {
 

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/BehaviorTree.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/BehaviorTree.java
@@ -132,8 +132,8 @@ public class BehaviorTree<E> extends Task<E> {
 	}
 
 	@Override
-	public void reset () {
-		super.reset();
+	public void resetTask () {
+		super.resetTask();
 		tree = this;
 	}
 

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/BranchTask.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/BranchTask.java
@@ -70,5 +70,11 @@ public abstract class BranchTask<E> extends Task<E> {
 
 		return task;
 	}
+	
+	@Override
+	public void reset() {
+		children.clear();
+		super.reset();
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/Decorator.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/Decorator.java
@@ -98,5 +98,11 @@ public abstract class Decorator<E> extends Task<E> {
 
 		return task;
 	}
+	
+	@Override
+	public void reset() {
+		child = null;
+		super.reset();
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/LoopDecorator.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/LoopDecorator.java
@@ -65,5 +65,11 @@ public abstract class LoopDecorator<E> extends Decorator<E> {
 		super.childRunning(runningTask, reporter);
 		loop = false;
 	}
+	
+	@Override
+	public void reset() {
+		loop = false;
+		super.reset();
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/SingleRunningChildBranch.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/SingleRunningChildBranch.java
@@ -108,8 +108,8 @@ public abstract class SingleRunningChildBranch<E> extends BranchTask<E> {
 	}
 
 	@Override
-	public void reset () {
-		super.reset();
+	public void resetTask () {
+		super.resetTask();
 		this.currentChildIndex = 0;
 		this.runningChild = null;
 		this.randomChildren = null;

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/SingleRunningChildBranch.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/SingleRunningChildBranch.java
@@ -129,5 +129,13 @@ public abstract class SingleRunningChildBranch<E> extends BranchTask<E> {
 		System.arraycopy(children.items, 0, rndChildren, 0, children.size);
 		return rndChildren;
 	}
+	
+	@Override
+	public void reset() {
+		this.currentChildIndex = 0;
+		this.runningChild = null;
+		this.randomChildren = null;
+		super.reset();
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/Task.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/Task.java
@@ -239,10 +239,10 @@ public abstract class Task<E> {
 	}
 
 	/** Resets this task to make it restart from scratch on next run. */
-	public void reset () {
+	public void resetTask () {
 		if (status == Status.RUNNING) cancel();
 		for (int i = 0, n = getChildCount(); i < n; i++) {
-			getChild(i).reset();
+			getChild(i).resetTask();
 		}
 		status = Status.FRESH;
 		tree = null;

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/Task.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/Task.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.ai.btree;
 
 import com.badlogic.gdx.ai.btree.annotation.TaskConstraint;
+import com.badlogic.gdx.utils.Pool.Poolable;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.ReflectionException;
 
@@ -28,7 +29,7 @@ import com.badlogic.gdx.utils.reflect.ReflectionException;
  * @author implicit-invocation
  * @author davebaol */
 @TaskConstraint
-public abstract class Task<E> {
+public abstract class Task<E> implements Poolable {
 
 	/** The enumeration of the values that a task's status can have.
 	 * 
@@ -277,5 +278,13 @@ public abstract class Task<E> {
 	 * @return the given task for chaining
 	 * @throws TaskCloneException if the task cannot be successfully copied. */
 	protected abstract Task<E> copyTo (Task<E> task);
+	
+	@Override
+	public void reset() {
+		control = null;
+		guard = null;
+		status = Status.FRESH;
+		tree = null;
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/TaskCloner.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/TaskCloner.java
@@ -26,4 +26,10 @@ public interface TaskCloner {
 	 * @return the cloned task */
 	public <T> Task<T> cloneTask (Task<T> task);
 
+	/**
+	 * Free task previously created by this {@link TaskCloner}
+	 * @param task task to free
+	 */
+	public <T> void freeTask(Task<T> task);
+
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/DynamicGuardSelector.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/DynamicGuardSelector.java
@@ -100,8 +100,8 @@ public class DynamicGuardSelector<E> extends BranchTask<E> {
 	}
 
 	@Override
-	public void reset () {
-		super.reset();
+	public void resetTask () {
+		super.resetTask();
 		this.runningChild = null;
 	}
 

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/DynamicGuardSelector.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/DynamicGuardSelector.java
@@ -113,4 +113,9 @@ public class DynamicGuardSelector<E> extends BranchTask<E> {
 		return super.copyTo(task);
 	}
 
+	@Override
+	public void reset() {
+		runningChild = null;
+		super.reset();
+	}
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -242,6 +242,7 @@ public class Parallel<E> extends BranchTask<E> {
 	@Override
 	public void reset() {
 		policy = Policy.Sequence;
+		orchestrator = Orchestrator.Resume;
 		noRunningTasks = true;
 		lastResult = null;
 		currentChildIndex = 0;

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -141,6 +141,15 @@ public class Parallel<E> extends BranchTask<E> {
 
 		return super.copyTo(task);
 	}
+	
+	@Override
+	public void reset() {
+		policy = Policy.Sequence;
+		noRunningTasks = true;
+		lastResult = null;
+		currentChildIndex = 0;
+		super.reset();
+	}
 
 	/** The enumeration of the policies supported by the {@link Parallel} task. */
 	public enum Policy {

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -129,8 +129,8 @@ public class Parallel<E> extends BranchTask<E> {
 	}
 
 	@Override
-	public void reset () {
-		super.reset();
+	public void resetTask () {
+		super.resetTask();
 		noRunningTasks = true;
 	}
 

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Include.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Include.java
@@ -101,4 +101,11 @@ public class Include<E> extends Decorator<E> {
 	private Task<E> createSubtreeRootTask () {
 		return BehaviorTreeLibraryManager.getInstance().createRootTask(subtree);
 	}
+	
+	@Override
+	public void reset() {
+		lazy = false;
+		subtree = null;
+		super.reset();
+	}
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Random.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Random.java
@@ -115,4 +115,10 @@ public class Random<E> extends Decorator<E> {
 		return super.copyTo(task);
 	}
 
+	@Override
+	public void reset() {
+		this.p = 0;
+		this.success = ConstantFloatDistribution.ZERO_POINT_FIVE;
+		super.reset();
+	}
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Repeat.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Repeat.java
@@ -97,4 +97,11 @@ public class Repeat<E> extends LoopDecorator<E> {
 
 		return super.copyTo(task);
 	}
+	
+	@Override
+	public void reset() {
+		count = 0;
+		times = null;
+		super.reset();
+	}
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/SemaphoreGuard.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/SemaphoreGuard.java
@@ -110,8 +110,8 @@ public class SemaphoreGuard<E> extends Decorator<E> {
 	}
 
 	@Override
-	public void reset () {
-		super.reset();
+	public void resetTask () {
+		super.resetTask();
 		semaphore = null;
 		semaphoreAcquired = false;
 	}

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/SemaphoreGuard.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/SemaphoreGuard.java
@@ -125,4 +125,12 @@ public class SemaphoreGuard<E> extends Decorator<E> {
 
 		return super.copyTo(task);
 	}
+	
+	@Override
+	public void reset() {
+		name = null;
+		semaphore = null;
+		semaphoreAcquired = false;
+		super.reset();
+	}
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/leaf/Wait.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/leaf/Wait.java
@@ -83,4 +83,12 @@ public class Wait<E> extends LeafTask<E> {
 		return task;
 	}
 
+	@Override
+	public void reset() {
+		seconds = ConstantFloatDistribution.ZERO;
+		startTime = 0;
+		timeout = 0;
+		super.reset();
+	}
+	
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeLibrary.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeLibrary.java
@@ -151,5 +151,16 @@ public class BehaviorTreeLibrary {
 	public boolean hasArchetypeTree (String treeReference) {
 		return repository.containsKey(treeReference);
 	}
+	
+	/**
+	 * Dispose behavior tree obtain by this library.
+	 * @param treeReference the tree identifier.
+	 * @param behaviorTree the tree to dispose.
+	 */
+	public void disposeBehaviorTree(String treeReference, BehaviorTree<?> behaviorTree){
+		if(Task.TASK_CLONER != null){
+			Task.TASK_CLONER.freeTask(behaviorTree);
+		}
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeLibraryManager.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeLibraryManager.java
@@ -80,5 +80,14 @@ public final class BehaviorTreeLibraryManager {
 	public <T> BehaviorTree<T> createBehaviorTree (String treeReference, T blackboard) {
 		return library.createBehaviorTree(treeReference, blackboard);
 	}
+	
+	/**
+	 * Dispose behavior tree obtain by this library manager.
+	 * @param treeReference the tree identifier.
+	 * @param behaviorTree the tree to dispose.
+	 */
+	public void disposeBehaviorTree(String treeReference, BehaviorTree<?> behaviorTree){
+		library.disposeBehaviorTree(treeReference, behaviorTree);
+	}
 
 }

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/PooledBehaviorTreeLibrary.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/PooledBehaviorTreeLibrary.java
@@ -1,0 +1,84 @@
+package com.badlogic.gdx.ai.btree.utils;
+
+import com.badlogic.gdx.ai.btree.BehaviorTree;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.ObjectMap.Entry;
+import com.badlogic.gdx.utils.Pool;
+
+/** A {@code BehaviorTreeLibrary} using reference pool.
+ * 
+ * {@link BehaviorTree} created by {@link PooledBehaviorTreeLibrary} should be disposed by
+ * calling {@link BehaviorTreeLibrary#disposeBehaviorTree(String, BehaviorTree)}.
+ * 
+ * @author mgsx
+ *
+ */
+@SuppressWarnings("rawtypes")
+public class PooledBehaviorTreeLibrary extends BehaviorTreeLibrary
+{
+	protected ObjectMap<String, Pool<BehaviorTree>> pools = new ObjectMap<String, Pool<BehaviorTree>>();
+	
+	/**
+	 * retrieve pool by tree reference, create it if not already exists.
+	 * @param treeReference
+	 * @return existing or newly created pool.
+	 */
+	protected Pool<BehaviorTree> getPool(final String treeReference){
+		Pool<BehaviorTree> treePool = pools.get(treeReference);
+		if(treePool == null){
+			treePool = new Pool<BehaviorTree>(){
+				@Override
+				protected BehaviorTree newObject() {
+					return newBehaviorTree(treeReference);
+				}
+			};
+			pools.put(treeReference, treePool);
+		}
+		return treePool;
+	}
+	
+	/**
+	 * creates concrete tree instance.
+	 * @param treeReference
+	 * @return a new tree instance.
+	 */
+	protected <T> BehaviorTree<T> newBehaviorTree (String treeReference) {
+		return super.createBehaviorTree(treeReference, null);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> BehaviorTree<T> createBehaviorTree(String treeReference, T blackboard) {
+		Pool<BehaviorTree> pool = getPool(treeReference);
+		BehaviorTree<T> tree = (BehaviorTree<T>)pool.obtain();
+		tree.setObject(blackboard);
+		return tree;
+	}
+	
+	@Override
+	public void disposeBehaviorTree(final String treeReference, BehaviorTree<?> behaviorTree) {
+		Pool<BehaviorTree> pool = getPool(treeReference);
+		pool.free(behaviorTree);
+	}
+	
+	/**
+	 * Clear pool for a tree reference.
+	 * @param treeReference
+	 */
+	public void clear(String treeReference){
+		Pool<BehaviorTree> treePool = pools.get(treeReference);
+		if(treePool != null){
+			treePool.clear();
+		}
+	}
+	
+	/**
+	 * clear all pools.
+	 */
+	public void clear(){
+		for(Entry<String, Pool<BehaviorTree>> entry : pools.entries()){
+			entry.value.clear();
+		}
+		pools.clear();
+	}
+}

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/BehaviorTreeTestBase.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/BehaviorTreeTestBase.java
@@ -72,7 +72,7 @@ public abstract class BehaviorTreeTestBase {
 
 	public void dispose () {
 		for (BehaviorTreeViewer<?> treeViewer : treeViewers)
-			treeViewer.getBehaviorTree().reset();
+			treeViewer.getBehaviorTree().resetTask();
 		treeViewers.clear();
 	}
 }

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/BehaviorTreeViewer.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/BehaviorTreeViewer.java
@@ -135,7 +135,7 @@ public class BehaviorTreeViewer<E> extends Table {
 		resetButton.addListener(new ChangeListener() {
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
-				BehaviorTreeViewer.this.tree.reset();
+				BehaviorTreeViewer.this.tree.resetTask();
 				rebuildDisplayTree();
 			}
 		});

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/dog/BarkTask.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/dog/BarkTask.java
@@ -53,4 +53,11 @@ public class BarkTask extends LeafTask<Dog> {
 		return task;
 	}
 
+	@Override
+	public void reset() {
+		times = ConstantIntegerDistribution.ONE;
+		t = 0;
+		super.reset();
+	}
+	
 }

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/dog/CareTask.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/dog/CareTask.java
@@ -44,4 +44,10 @@ public class CareTask extends LeafTask<Dog> {
 		return task;
 	}
 
+	@Override
+	public void reset() {
+		urgentProb = 0.8f;
+		super.reset();
+	}
+	
 }

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/dog/MarkTask.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/dog/MarkTask.java
@@ -46,4 +46,9 @@ public class MarkTask extends LeafTask<Dog> {
 		return task;
 	}
 
+	@Override
+	public void reset() {
+		i = 0;
+		super.reset();
+	}
 }

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/dog/WalkTask.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/dog/WalkTask.java
@@ -49,5 +49,11 @@ public class WalkTask extends LeafTask<Dog> {
 	protected Task<Dog> copyTo (Task<Dog> task) {
 		return task;
 	}
+	
+	@Override
+	public void reset() {
+		i = 0;
+		super.reset();
+	}
 
 }

--- a/tests/src/com/badlogic/gdx/ai/tests/btree/tests/ParseAndCloneTreeTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/btree/tests/ParseAndCloneTreeTest.java
@@ -67,6 +67,9 @@ public class ParseAndCloneTreeTest extends BehaviorTreeTestBase {
 				public <T> Task<T> cloneTask (Task<T> task) {
 					return KryoUtils.copy(task);
 				}
+				@Override
+				public <T> void freeTask(Task<T> task) {
+				}
 			};
 			BehaviorTree<Dog> tree = (BehaviorTree<Dog>)treeArchetype.cloneTask();
 			tree.setObject(new Dog("Cloned Buddy"));


### PR DESCRIPTION
As discussed in #12, here is changes to make behavior trees poolable.

Pool strategy can be configured as follow : 
* If you need to pool entire trees, you can use the PooledBehaviorTreeLibrary implementation (or one of yours). Pools are indexed by tree reference. Shouldn't be used if you modify tree after creation.
* If you need to pool individual tasks types, you have to implement pooling in your TaskCloner.
* By default, trees and tasks are not pooled at all (for compatibility).

@davebaol : there is one minor impact in wiki (call to "reset" method have to be replaced by "resetTask") but i can't PR wiki changes with github. Maybe a pool subtopic would be helpful for developers.

Please feel free to make suggestions about design/code, I'll try to fix ASAP.