### PR TITLE
allow unsupported type parsing for task attributes

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeParser.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeParser.java
@@ -392,6 +392,7 @@ public class BehaviorTreeParser<E> {
 		private void setField (Field field, Task<E> task, Object value) {
 			field.setAccessible(true);
 			Object valueObject = castValue(field, value);
+			if (valueObject == null) throwAttributeTypeException(getCurrentTask().name, field.getName(), field.getType().getSimpleName());
 			try {
 				field.set(task, valueObject);
 			} catch (ReflectionException e) {
@@ -399,7 +400,15 @@ public class BehaviorTreeParser<E> {
 			}
 		}
 
-		private Object castValue (Field field, Object value) {
+		/**
+		 * Convert serialized value to java value.
+		 * Parsed value must be assignable to field argument.
+		 * Subclasses may override this method to parse unsupported types.
+		 * @param field task attribute field
+		 * @param value unparsed value (can be Number, String or Boolean)
+		 * @return parsed value or null if field type is not supported.
+		 */
+		protected Object castValue (Field field, Object value) {
 			Class<?> type = field.getType();
 			Object ret = null;
 			if (value instanceof Number) {
@@ -445,7 +454,6 @@ public class BehaviorTreeParser<E> {
 					}
 				}
 			}
-			if (ret == null) throwAttributeTypeException(getCurrentTask().name, field.getName(), type.getSimpleName());
 			return ret;
 		}
 


### PR DESCRIPTION
These changes allow custom behavior tree parser to support types that are not supported in default parser.

One of my use case is to allow Interpolation (gdx.math) type for some task attributes. Since there is several ways to parse such type, I think it's better to let developers subclass default parser and implement it as they want. 

Interpolation could be handled like this : 
* It could be simple strings like "linear", "sine", "swingOut"...
* It could be more complex definition like distributions : "pow,2", "pow,3.7"...

There might be better solution inspired by JSON.Serializer (distribution parsing could be implemented in serializer as well) but it implies more changes and maybe some drawbacks.

What do you think ?