### PR TITLE
Parallel task now supports different child execution strategies

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -18,11 +18,20 @@ package com.badlogic.gdx.ai.btree.branch;
 
 import com.badlogic.gdx.ai.btree.BranchTask;
 import com.badlogic.gdx.ai.btree.Task;
+import com.badlogic.gdx.ai.btree.Task.Status;
 import com.badlogic.gdx.ai.btree.annotation.TaskAttribute;
 import com.badlogic.gdx.utils.Array;
 
-/** A {@code Parallel} is a special branch task that starts or resumes all children every single time. The actual behavior of
- * parallel task depends on its {@link #policy}:
+/** A {@code Parallel} is a special branch task that runs all children when stepped. 
+ * It's actual behavior depends on its {@link strategy} and {@link policy}.<br>
+ * <br>
+ * The execution of the parallel task's children depends on its {@link #strategy}:
+ * <ul>
+ * <li>{@link Strategy#Resume}: the parallel task restarts or runs each child every step</li>
+ * <li>{@link Strategy#Join}: child tasks will run until success or failure but will not re-run until the parallel task has succeeded or failed</li>
+ * </ul>
+ * 
+ * The actual result of the parallel task depends on its {@link #policy}:
  * <ul>
  * <li>{@link Policy#Sequence}: the parallel task fails as soon as one child fails; if all children succeed, then the parallel
  * task succeeds. This is the default policy.</li>
@@ -40,77 +49,78 @@ public class Parallel<E> extends BranchTask<E> {
 
 	/** Optional task attribute specifying the parallel policy (defaults to {@link Policy#Sequence}) */
 	@TaskAttribute public Policy policy;
+	/** Optional task attribute specifying the execution policy (defaults to {@link Strategy#Resume}) */
+	@TaskAttribute public Strategy strategy;
 
 	private boolean noRunningTasks;
 	private Boolean lastResult;
 	private int currentChildIndex;
 
-	/** Creates a parallel task with sequence policy and no children */
+	/** Creates a parallel task with sequence policy, resume strategy and no children */
 	public Parallel () {
 		this(new Array<Task<E>>());
 	}
 
-	/** Creates a parallel task with sequence policy and the given children
+	/** Creates a parallel task with sequence policy, resume strategy and the given children
 	 * @param tasks the children */
 	public Parallel (Task<E>... tasks) {
 		this(new Array<Task<E>>(tasks));
 	}
 
-	/** Creates a parallel task with sequence policy and the given children
+	/** Creates a parallel task with sequence policy, resume strategy and the given children
 	 * @param tasks the children */
 	public Parallel (Array<Task<E>> tasks) {
 		this(Policy.Sequence, tasks);
 	}
 
-	/** Creates a parallel task with the given policy and no children
+	/** Creates a parallel task with the given policy, resume strategy and no children
 	 * @param policy the policy */
 	public Parallel (Policy policy) {
 		this(policy, new Array<Task<E>>());
 	}
 
-	/** Creates a parallel task with the given policy and children
+	/** Creates a parallel task with the given policy, resume strategy and the given children
 	 * @param policy the policy
 	 * @param tasks the children */
 	public Parallel (Policy policy, Task<E>... tasks) {
 		this(policy, new Array<Task<E>>(tasks));
 	}
 
-	/** Creates a parallel task with the given policy and children
+	/** Creates a parallel task with the given policy, resume strategy and the given children
 	 * @param policy the policy
 	 * @param tasks the children */
 	public Parallel (Policy policy, Array<Task<E>> tasks) {
+		this(policy, Strategy.Resume, tasks);
+	}
+
+	/** Creates a parallel task with the given strategy, sequence policy and the given children
+	 * @param strategy the strategy
+	 * @param tasks the children */
+	public Parallel (Strategy strategy, Array<Task<E>> tasks) {
+		this(Policy.Sequence, strategy, tasks);
+	}
+	
+	/** Creates a parallel task with the given strategy, sequence policy and the given children
+	 * @param strategy the strategy
+	 * @param tasks the children */
+	public Parallel (Strategy strategy, Task<E>... tasks) {
+		this(Policy.Sequence, strategy, new Array<Task<E>>(tasks));
+	}
+	
+	/** Creates a parallel task with the given strategy, policy and children
+	 * @param policy the policy
+	 * @param strategy the strategy
+	 * @param tasks the children */
+	public Parallel (Policy policy, Strategy strategy, Array<Task<E>> tasks) {
 		super(tasks);
 		this.policy = policy;
+		this.strategy = strategy;
 		noRunningTasks = true;
 	}
 
 	@Override
 	public void run () {
-		noRunningTasks = true;
-		lastResult = null;
-		for (currentChildIndex = 0; currentChildIndex < children.size; currentChildIndex++) {
-			Task<E> child = children.get(currentChildIndex);
-			if (child.getStatus() == Status.RUNNING) {
-				child.run();
-			} else {
-				child.setControl(this);
-				child.start();
-				if (child.checkGuard(this))
-					child.run();
-				else
-					child.fail();
-			}
-
-			if (lastResult != null) { // Current child has finished either with success or fail
-				cancelRunningChildren(noRunningTasks ? currentChildIndex + 1 : 0);
-				if (lastResult)
-					success();
-				else
-					fail();
-				return;
-			}
-		}
-		running();
+		strategy.execute(this);
 	}
 
 	@Override
@@ -138,8 +148,95 @@ public class Parallel<E> extends BranchTask<E> {
 	protected Task<E> copyTo (Task<E> task) {
 		Parallel<E> parallel = (Parallel<E>)task;
 		parallel.policy = policy; // no need to clone since it is immutable
-
+		parallel.strategy = strategy; // no need to clone since it is immutable
 		return super.copyTo(task);
+	}
+	
+	public void resetAllChildren() {
+		for (int i = 0, n = getChildCount(); i < n; i++) {
+			Task<E> child = getChild(i);
+			child.reset();
+		}
+	}
+	
+	/** The enumeration of the child execution strategies supported by the {@link Parallel} task */
+	public enum Strategy {
+		/** The default strategy - starts or resumes all children every single step */
+		Resume() {
+			@Override
+			public void execute(Parallel<?> parallel) {
+				parallel.noRunningTasks = true;
+				parallel.lastResult = null;
+				for (parallel.currentChildIndex = 0; parallel.currentChildIndex < parallel.children.size; parallel.currentChildIndex++) {
+					Task child = parallel.children.get(parallel.currentChildIndex);
+					if (child.getStatus() == Status.RUNNING) {
+						child.run();
+					} else {
+						child.setControl(parallel);
+						child.start();
+						if (child.checkGuard(parallel))
+							child.run();
+						else
+							child.fail();
+					}
+
+					if (parallel.lastResult != null) { // Current child has finished either with success or fail
+						parallel.cancelRunningChildren(parallel.noRunningTasks ? parallel.currentChildIndex + 1 : 0);
+						if (parallel.lastResult)
+							parallel.success();
+						else
+							parallel.fail();
+						return;
+					}
+				}
+				parallel.running();
+			}
+		},
+		/** Children execute until they succeed or fail but will not re-run until the parallel task has succeeded or failed */
+		Join() {
+			@Override
+			public void execute(Parallel<?> parallel) {
+				parallel.noRunningTasks = true;
+				parallel.lastResult = null;
+				for (parallel.currentChildIndex = 0; parallel.currentChildIndex < parallel.children.size; parallel.currentChildIndex++) {
+					Task child = parallel.children.get(parallel.currentChildIndex);
+					
+					switch(child.getStatus()) {
+					case RUNNING:
+						child.run();
+						break;
+					case SUCCEEDED:
+					case FAILED:
+						break;
+					default:
+						child.setControl(parallel);
+						child.start();
+						if (child.checkGuard(parallel))
+							child.run();
+						else
+							child.fail();
+						break;
+					}
+					
+					if (parallel.lastResult != null) { // Current child has finished either with success or fail
+						parallel.cancelRunningChildren(parallel.noRunningTasks ? parallel.currentChildIndex + 1 : 0);
+						parallel.resetAllChildren();
+						if (parallel.lastResult)
+							parallel.success();
+						else
+							parallel.fail();
+						return;
+					}
+				}
+				parallel.running();
+			}
+		};
+		
+		/**
+		 * Called by parallel task each run
+		 * @param parallel The {@link Parallel} task
+		 */
+		public abstract void execute(Parallel<?> parallel);
 	}
 
 	/** The enumeration of the policies supported by the {@link Parallel} task. */

--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/branch/Parallel.java
@@ -246,7 +246,13 @@ public class Parallel<E> extends BranchTask<E> {
 		Sequence() {
 			@Override
 			public Boolean onChildSuccess (Parallel<?> parallel) {
-				return parallel.noRunningTasks && parallel.currentChildIndex == parallel.children.size - 1 ? Boolean.TRUE : null;
+				switch(parallel.strategy) {
+				case Join:
+					return parallel.noRunningTasks && parallel.children.get(parallel.children.size - 1).getStatus() == Status.SUCCEEDED ? Boolean.TRUE : null;
+				case Resume:
+				default:
+					return parallel.noRunningTasks && parallel.currentChildIndex == parallel.children.size - 1 ? Boolean.TRUE : null;
+				}
 			}
 
 			@Override

--- a/gdx-ai/tests/com/badlogic/gdx/ai/btree/branch/ParallelTest.java
+++ b/gdx-ai/tests/com/badlogic/gdx/ai/btree/branch/ParallelTest.java
@@ -53,7 +53,7 @@ public class ParallelTest {
 		Assert.assertEquals(1, task2.executions);
 		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
 
-		task1.status = Status.SUCCEEDED;
+		task2.status = Status.SUCCEEDED;
 		behaviorTree.step();
 
 		Assert.assertEquals(2, task1.executions);
@@ -66,7 +66,7 @@ public class ParallelTest {
 		Assert.assertEquals(3, task2.executions);
 		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
 
-		task2.status = Status.SUCCEEDED;
+		task1.status = Status.SUCCEEDED;
 		behaviorTree.step();
 
 		Assert.assertEquals(4, task1.executions);
@@ -115,7 +115,7 @@ public class ParallelTest {
 	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
 	 */
 	@Test
-	public void testJoinStrategySequencePolicy() {
+	public void testJoinStrategySequencePolicySequentialOrder() {
 		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Join, tasks);
 		behaviorTree.addChild(parallel);
 		behaviorTree.step();
@@ -152,6 +152,52 @@ public class ParallelTest {
 		behaviorTree.step();
 		Assert.assertEquals(3, task1.executions);
 		Assert.assertEquals(5, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+	}
+	
+	/**
+	 * Join stategy - all tasks run until success/failure then don't run again
+	 * until the parallel task has succeeded or failed<br>
+	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
+	 */
+	@Test
+	public void testJoinStrategySequencePolicyInverseOrder() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Join, tasks);
+		behaviorTree.addChild(parallel);
+		behaviorTree.step();
+
+		Assert.assertEquals(1, task1.executions);
+		Assert.assertEquals(1, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task2.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		behaviorTree.step();
+
+		// Join strategy - task 2 will not execute again until the parallel task
+		// succeeds or fails
+		Assert.assertEquals(3, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task1.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(4, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+
+		task1.status = Status.RUNNING;
+		task2.status = Status.RUNNING;
+
+		behaviorTree.step();
+		Assert.assertEquals(5, task1.executions);
+		Assert.assertEquals(3, task2.executions);
 		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
 	}
 

--- a/gdx-ai/tests/com/badlogic/gdx/ai/btree/branch/ParallelTest.java
+++ b/gdx-ai/tests/com/badlogic/gdx/ai/btree/branch/ParallelTest.java
@@ -24,7 +24,7 @@ import com.badlogic.gdx.ai.btree.LeafTask;
 import com.badlogic.gdx.ai.btree.Task;
 import com.badlogic.gdx.ai.btree.Task.Status;
 import com.badlogic.gdx.ai.btree.branch.Parallel.Policy;
-import com.badlogic.gdx.ai.btree.branch.Parallel.Strategy;
+import com.badlogic.gdx.ai.btree.branch.Parallel.Orchestrator;
 import com.badlogic.gdx.utils.Array;
 
 public class ParallelTest {
@@ -40,12 +40,12 @@ public class ParallelTest {
 	}
 
 	/**
-	 * Resume stategy - all tasks start or run on each step<br>
+	 * Resume orchestrator - all tasks start or run on each step<br>
 	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
 	 */
 	@Test
-	public void testResumeStrategySequencePolicy() {
-		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Resume, tasks);
+	public void testResumeOrchestratorSequencePolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Orchestrator.Resume, tasks);
 		behaviorTree.addChild(parallel);
 		behaviorTree.step();
 
@@ -75,12 +75,12 @@ public class ParallelTest {
 	}
 
 	/**
-	 * Resume stategy - all tasks start or run on each step<br>
+	 * Resume orchestrator - all tasks start or run on each step<br>
 	 * Selector policy - only one task has to succeed for the parallel task to succeed
 	 */
 	@Test
-	public void testResumeStrategySelectorPolicy() {
-		Parallel<String> parallel = new Parallel<String>(Policy.Selector, Strategy.Resume, tasks);
+	public void testResumeOrchestratorSelectorPolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Selector, Orchestrator.Resume, tasks);
 		behaviorTree.addChild(parallel);
 		behaviorTree.step();
 
@@ -110,13 +110,13 @@ public class ParallelTest {
 	}
 
 	/**
-	 * Join stategy - all tasks run until success/failure then don't run again
+	 * Join orchestrator - all tasks run until success/failure then don't run again
 	 * until the parallel task has succeeded or failed<br>
 	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
 	 */
 	@Test
-	public void testJoinStrategySequencePolicySequentialOrder() {
-		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Join, tasks);
+	public void testJoinOrchestratorSequencePolicySequentialOrder() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Orchestrator.Join, tasks);
 		behaviorTree.addChild(parallel);
 		behaviorTree.step();
 
@@ -156,13 +156,13 @@ public class ParallelTest {
 	}
 	
 	/**
-	 * Join stategy - all tasks run until success/failure then don't run again
+	 * Join orchestrator - all tasks run until success/failure then don't run again
 	 * until the parallel task has succeeded or failed<br>
 	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
 	 */
 	@Test
-	public void testJoinStrategySequencePolicyInverseOrder() {
-		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Join, tasks);
+	public void testJoinOrchestratorSequencePolicyInverseOrder() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Orchestrator.Join, tasks);
 		behaviorTree.addChild(parallel);
 		behaviorTree.step();
 
@@ -202,13 +202,13 @@ public class ParallelTest {
 	}
 
 	/**
-	 * Join stategy - all tasks run until success/failure then don't run again
+	 * Join orchestrator - all tasks run until success/failure then don't run again
 	 * until the parallel task has succeeded or failed<br>
 	 * Selector policy - only one task has to succeed for the parallel task to succeed
 	 */
 	@Test
-	public void testJoinStrategySelectorPolicy() {
-		Parallel<String> parallel = new Parallel<String>(Policy.Selector, Strategy.Join, tasks);
+	public void testJoinOrchestratorSelectorPolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Selector, Orchestrator.Join, tasks);
 		behaviorTree.addChild(parallel);
 		behaviorTree.step();
 

--- a/gdx-ai/tests/com/badlogic/gdx/ai/btree/branch/ParallelTest.java
+++ b/gdx-ai/tests/com/badlogic/gdx/ai/btree/branch/ParallelTest.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright 2017 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.badlogic.gdx.ai.btree.branch;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.badlogic.gdx.ai.btree.BehaviorTree;
+import com.badlogic.gdx.ai.btree.LeafTask;
+import com.badlogic.gdx.ai.btree.Task;
+import com.badlogic.gdx.ai.btree.Task.Status;
+import com.badlogic.gdx.ai.btree.branch.Parallel.Policy;
+import com.badlogic.gdx.ai.btree.branch.Parallel.Strategy;
+import com.badlogic.gdx.utils.Array;
+
+public class ParallelTest {
+	private final BehaviorTree<String> behaviorTree = new BehaviorTree<String>();
+	private final TestTask task1 = new TestTask();
+	private final TestTask task2 = new TestTask();
+	private final Array<Task<String>> tasks = new Array<Task<String>>();
+
+	@Before
+	public void setUp() {
+		tasks.add(task1);
+		tasks.add(task2);
+	}
+
+	/**
+	 * Resume stategy - all tasks start or run on each step<br>
+	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
+	 */
+	@Test
+	public void testResumeStrategySequencePolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Resume, tasks);
+		behaviorTree.addChild(parallel);
+		behaviorTree.step();
+
+		Assert.assertEquals(1, task1.executions);
+		Assert.assertEquals(1, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task1.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		behaviorTree.step();
+
+		Assert.assertEquals(3, task1.executions);
+		Assert.assertEquals(3, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task2.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(4, task1.executions);
+		Assert.assertEquals(4, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+	}
+
+	/**
+	 * Resume stategy - all tasks start or run on each step<br>
+	 * Selector policy - only one task has to succeed for the parallel task to succeed
+	 */
+	@Test
+	public void testResumeStrategySelectorPolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Selector, Strategy.Resume, tasks);
+		behaviorTree.addChild(parallel);
+		behaviorTree.step();
+
+		Assert.assertEquals(1, task1.executions);
+		Assert.assertEquals(1, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task1.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(3, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+
+		behaviorTree.step();
+
+		// Resume strategy - all tasks start/run
+		Assert.assertEquals(4, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+	}
+
+	/**
+	 * Join stategy - all tasks run until success/failure then don't run again
+	 * until the parallel task has succeeded or failed<br>
+	 * Sequence policy - all tasks have to succeed for the parallel task to succeed
+	 */
+	@Test
+	public void testJoinStrategySequencePolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Sequence, Strategy.Join, tasks);
+		behaviorTree.addChild(parallel);
+		behaviorTree.step();
+
+		Assert.assertEquals(1, task1.executions);
+		Assert.assertEquals(1, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task1.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		behaviorTree.step();
+
+		// Join strategy - task 1 will not execute again until the parallel task
+		// succeeds or fails
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(3, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task2.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(4, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+
+		task1.status = Status.RUNNING;
+		task2.status = Status.RUNNING;
+
+		behaviorTree.step();
+		Assert.assertEquals(3, task1.executions);
+		Assert.assertEquals(5, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+	}
+
+	/**
+	 * Join stategy - all tasks run until success/failure then don't run again
+	 * until the parallel task has succeeded or failed<br>
+	 * Selector policy - only one task has to succeed for the parallel task to succeed
+	 */
+	@Test
+	public void testJoinStrategySelectorPolicy() {
+		Parallel<String> parallel = new Parallel<String>(Policy.Selector, Strategy.Join, tasks);
+		behaviorTree.addChild(parallel);
+		behaviorTree.step();
+
+		Assert.assertEquals(1, task1.executions);
+		Assert.assertEquals(1, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		task1.status = Status.FAILED;
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(2, task2.executions);
+		Assert.assertEquals(Status.RUNNING, parallel.getStatus());
+
+		// Join strategy - task 1 will not execute again until the parallel task
+		// succeeds or fails
+		task2.status = Status.SUCCEEDED;
+		behaviorTree.step();
+
+		Assert.assertEquals(2, task1.executions);
+		Assert.assertEquals(3, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+
+		behaviorTree.step();
+
+		Assert.assertEquals(3, task1.executions);
+		Assert.assertEquals(4, task2.executions);
+		Assert.assertEquals(Status.SUCCEEDED, parallel.getStatus());
+	}
+
+	private class TestTask extends LeafTask<String> {
+		Task.Status status = Status.RUNNING;
+		int executions = 0;
+
+		@Override
+		public com.badlogic.gdx.ai.btree.Task.Status execute() {
+			executions++;
+			return status;
+		}
+
+		@Override
+		protected Task<String> copyTo(Task<String> task) {
+			return task;
+		}
+	}
+}

--- a/tests/src/com/badlogic/gdx/ai/tests/BehaviorTreeTests.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/BehaviorTreeTests.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.ai.tests.btree.tests.ParallelVsSequenceTest;
 import com.badlogic.gdx.ai.tests.btree.tests.ParseAndCloneTreeTest;
 import com.badlogic.gdx.ai.tests.btree.tests.ParseTreeTest;
 import com.badlogic.gdx.ai.tests.btree.tests.ProgrammaticallyCreatedTreeTest;
+import com.badlogic.gdx.ai.tests.btree.tests.ResumeVsJoinTest;
 import com.badlogic.gdx.ai.tests.btree.tests.SemaphoreGuardTest;
 import com.badlogic.gdx.ai.tests.utils.GdxAiTestUtils;
 import com.badlogic.gdx.ai.tests.utils.scene2d.FpsLabel;
@@ -73,6 +74,7 @@ public class BehaviorTreeTests extends Game {
 			new IncludeSubtreeTest(false),
 			new IncludeSubtreeTest(true),
 			new ParallelVsSequenceTest(BehaviorTreeTests.this),
+			new ResumeVsJoinTest(BehaviorTreeTests.this),
 			new ProgrammaticallyCreatedTreeTest(false),
 			new ProgrammaticallyCreatedTreeTest(true),
 			new SemaphoreGuardTest()


### PR DESCRIPTION
Hi all,

I've implemented an additional execution strategy for child tasks of the Parallel task.

- The Resume strategy is the original method which restarts or runs each child every step.
- The new strategy is called Join. Child tasks will run until success or failure but will not re-run until the parallel task has succeeded or failed.

I've set the default to the Resume strategy to maintain compatibility for everyone. I've also added until tests for the different combinations of strategy + policy.

Comments and feedback welcome :)