### PR TITLE
"Time to target" must not be set to 0

### DIFF
--- a/tests/src/com/badlogic/gdx/ai/tests/steer/box2d/tests/Box2dArriveTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/steer/box2d/tests/Box2dArriveTest.java
@@ -111,7 +111,7 @@ public class Box2dArriveTest extends Box2dSteeringTest {
 		final Label labelTimeToTarget = new Label("Time to Target [" + arriveSB.getTimeToTarget() + " sec.]", container.skin);
 		detailTable.add(labelTimeToTarget);
 		detailTable.row();
-		Slider timeToTarget = new Slider(0, 3, 0.1f, false, container.skin);
+		Slider timeToTarget = new Slider(0.01f, 3, 0.1f, false, container.skin);
 		timeToTarget.setValue(arriveSB.getTimeToTarget());
 		timeToTarget.addListener(new ChangeListener() {
 			@Override

--- a/tests/src/com/badlogic/gdx/ai/tests/steer/box2d/tests/Box2dLookWhereYouAreGoingTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/steer/box2d/tests/Box2dLookWhereYouAreGoingTest.java
@@ -130,7 +130,7 @@ public class Box2dLookWhereYouAreGoingTest extends Box2dSteeringTest {
 			container.skin);
 		detailTable.add(labelTimeToTarget);
 		detailTable.row();
-		Slider timeToTarget = new Slider(0, 3, 0.1f, false, container.skin);
+		Slider timeToTarget = new Slider(0.01f, 3, 0.1f, false, container.skin);
 		timeToTarget.setValue(lookWhereYouAreGoingSB.getTimeToTarget());
 		timeToTarget.addListener(new ChangeListener() {
 			@Override

--- a/tests/src/com/badlogic/gdx/ai/tests/steer/bullet/tests/BulletLookWhereYouAreGoingTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/steer/bullet/tests/BulletLookWhereYouAreGoingTest.java
@@ -136,7 +136,7 @@ public class BulletLookWhereYouAreGoingTest extends BulletSteeringTest {
 			container.skin);
 		detailTable.add(labelTimeToTarget);
 		detailTable.row();
-		Slider timeToTarget = new Slider(0, 1, 0.1f, false, container.skin);
+		Slider timeToTarget = new Slider(0.01f, 1, 0.1f, false, container.skin);
 		timeToTarget.setValue(lookWhereYouAreGoingSB.getTimeToTarget());
 		timeToTarget.addListener(new ChangeListener() {
 			@Override

--- a/tests/src/com/badlogic/gdx/ai/tests/steer/scene2d/tests/Scene2dHideTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/steer/scene2d/tests/Scene2dHideTest.java
@@ -177,7 +177,7 @@ public class Scene2dHideTest extends Scene2dSteeringTest {
 		final Label labelTimeToTarget = new Label("Time to Target [" + hideSB.getTimeToTarget() + " sec.]", container.skin);
 		detailTable.add(labelTimeToTarget);
 		detailTable.row();
-		Slider timeToTarget = new Slider(0, 3, 0.1f, false, container.skin);
+		Slider timeToTarget = new Slider(0.01f, 3, 0.1f, false, container.skin);
 		timeToTarget.setValue(hideSB.getTimeToTarget());
 		timeToTarget.addListener(new ChangeListener() {
 			@Override

--- a/tests/src/com/badlogic/gdx/ai/tests/steer/scene2d/tests/Scene2dLookWhereYouAreGoingTest.java
+++ b/tests/src/com/badlogic/gdx/ai/tests/steer/scene2d/tests/Scene2dLookWhereYouAreGoingTest.java
@@ -127,7 +127,7 @@ public class Scene2dLookWhereYouAreGoingTest extends Scene2dSteeringTest {
 			container.skin);
 		detailTable.add(labelTimeToTarget);
 		detailTable.row();
-		Slider timeToTarget = new Slider(0, 3, 0.1f, false, container.skin);
+		Slider timeToTarget = new Slider(0.01f, 3, 0.1f, false, container.skin);
 		timeToTarget.setValue(lookWhereYouAreGoingSB.getTimeToTarget());
 		timeToTarget.addListener(new ChangeListener() {
 			@Override


### PR DESCRIPTION
While playing with SteeringBehavior tests, I have noticed that some of the sliders allow to set the zero value for "Time to target".
However, the behavior utilizes this value as 
`targetVelocity.sub(owner.getLinearVelocity()).scl(1f / timeToTarget).limit(actualLimiter.getMaxLinearAcceleration()); ` 
where 0-value leads to division by zero and silent crash (in the tests the character just disappear and can't be restored).

I come with two options to fix that:
1) correct the behavior code: to perform a check for such wrong input, and when it happens to use some non-zero value.
2) correct the tests and do not allow to enter the wrong values.

This PR implements 2nd option.
I suggest leaving for user's own responsibility providing the correct values to the behavior algorithms in one's code; rather than slowing down the algorithm by excessive sanity checks and providing the behavior different from the input (though invalid input) parameters.