### PR TITLE
allow the option to use an external pool in MessageDispatcher

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
@@ -37,7 +37,7 @@ public class MessageDispatcher implements Telegraph {
 		}
 	};
 
-	private final Pool<Telegram> POOL;
+	private final Pool<Telegram> pool;
 
 	private PriorityQueue<Telegram> queue;
 
@@ -55,7 +55,7 @@ public class MessageDispatcher implements Telegraph {
 	public MessageDispatcher (Pool<Telegram> pool) {
 		if (pool == null)
 			throw new IllegalArgumentException("pool cannot be null");
-		POOL = pool;
+		this.pool = pool;
 		this.queue = new PriorityQueue<Telegram>();
 		this.msgListeners = new IntMap<Array<Telegraph>>();
 		this.msgProviders = new IntMap<Array<TelegramProvider>>();
@@ -189,7 +189,7 @@ public class MessageDispatcher implements Telegraph {
 	/** Removes all the telegrams from the queue and releases them to the internal pool. */
 	public void clearQueue () {
 		for (int i = 0; i < queue.size(); i++) {
-			POOL.free(queue.get(i));
+			pool.free(queue.get(i));
 		}
 		queue.clear();
 	}
@@ -475,7 +475,7 @@ public class MessageDispatcher implements Telegraph {
 			throw new IllegalArgumentException("Sender cannot be null when a return receipt is needed");
 
 		// Get a telegram from the pool
-		Telegram telegram = POOL.obtain();
+		Telegram telegram = pool.obtain();
 		telegram.sender = sender;
 		telegram.receiver = receiver;
 		telegram.message = msg;
@@ -508,7 +508,7 @@ public class MessageDispatcher implements Telegraph {
 			boolean added = queue.add(telegram);
 
 			// Return it to the pool if has been rejected
-			if (!added) POOL.free(telegram);
+			if (!added) pool.free(telegram);
 
 			if (debugEnabled) {
 				if (added)
@@ -607,7 +607,7 @@ public class MessageDispatcher implements Telegraph {
 			discharge(telegram);
 		} else {
 			// Release the telegram to the pool
-			POOL.free(telegram);
+			pool.free(telegram);
 		}
 	}
 

--- a/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
@@ -30,12 +30,14 @@ public class MessageDispatcher implements Telegraph {
 
 	private static final String LOG_TAG = MessageDispatcher.class.getSimpleName();
 
-	private static final Pool<Telegram> POOL = new Pool<Telegram>(16) {
+	private static final Pool<Telegram> POOL_GLOBAL = new Pool<Telegram>(16) {
 		@Override
 		protected Telegram newObject () {
 			return new Telegram();
 		}
 	};
+
+	private final Pool<Telegram> POOL;
 
 	private PriorityQueue<Telegram> queue;
 
@@ -47,6 +49,11 @@ public class MessageDispatcher implements Telegraph {
 
 	/** Creates a {@code MessageDispatcher} */
 	public MessageDispatcher () {
+		this(POOL_GLOBAL);
+	}
+
+	public MessageDispatcher (Pool<Telegram> pool) {
+		POOL = pool;
 		this.queue = new PriorityQueue<Telegram>();
 		this.msgListeners = new IntMap<Array<Telegraph>>();
 		this.msgProviders = new IntMap<Array<TelegramProvider>>();

--- a/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
@@ -53,6 +53,8 @@ public class MessageDispatcher implements Telegraph {
 	}
 
 	public MessageDispatcher (Pool<Telegram> pool) {
+		if (pool == null)
+			throw new IllegalArgumentException("pool cannot be null");
 		POOL = pool;
 		this.queue = new PriorityQueue<Telegram>();
 		this.msgListeners = new IntMap<Array<Telegraph>>();


### PR DESCRIPTION
Hi, as the title suggests, it would be helpful if the `MessageDispatcher` could take an external pool as a parameter, instead of always using the static pool. This is especially useful in parallel messaging situations, as I mentioned in #120.